### PR TITLE
reset progress value after completion

### DIFF
--- a/js/gym_minigame.js
+++ b/js/gym_minigame.js
@@ -34,6 +34,7 @@ function updateWeightliftingAnimation() {
 	} else {
 		appearance.change(appearance.getValue()+1);
 		alert("+1 appearance");
+		progress.value = 0;
 	}
 }
 


### PR DESCRIPTION
Feel free to merge this if you wish. I needed to contribute to an open source project for my HFOSS class at RIT. I noticed that the gym minigame had a slight bug where you could farm crazy amounts of appearance since the game didn't reset after winning.
